### PR TITLE
(HG3): fix img_jpg RGB swapping and img_al null-terminator check

### DIFF
--- a/ArcFormats/CatSystem/ImageHG3.cs
+++ b/ArcFormats/CatSystem/ImageHG3.cs
@@ -306,16 +306,16 @@ namespace GameRes.Formats.CatSystem
             int dst = 0;
             for (uint i = 0; i < total; ++i)
             {
-                output[dst++] = pixels[src+2];
-                output[dst++] = pixels[src+1];
                 output[dst++] = pixels[src];
+                output[dst++] = pixels[src+1];
+                output[dst++] = pixels[src+2];
                 output[dst++] = 0xFF;
                 src += src_pixel_size;
             }
 
             m_input.Position = next_section;
             var section_header = m_input.ReadBytes (8);
-            if (!Binary.AsciiEqual (section_header, "img_al\0\0"))
+            if (!Binary.AsciiEqual (section_header, "img_al\0"))
                 return output;
             m_input.Seek (8, SeekOrigin.Current);
             int alpha_size = m_input.ReadInt32();


### PR DESCRIPTION
Multiple corrections to `img_jpg` unpacking in HG-3 images.

## Changes

* Switched RGB channel order during pixels copy: `"img_jpg"` tag format unpack operation was swapping RGB -> BGR when already in BGR format. 
* Removed second null-terminator in ASCII equals check: `"img_al"` tag name had two null-terminator checks. And *apparently...* CatSystem 2 does not guarantee anything after the first null-terminator in a fixed-length string *(yikes)*. This can be observed with a few assets in the `cs2_full_v301` toolset:
    * **be01S\_0000001.hg3:** `69 6D 67 5F 61 6C 00 B5` : `"img_al.5"`"
    * Note, however, that most `img_al` tags will have a clean two null bytes in the tag name, this seems to only be an infrequent issue.