### PR TITLE
(HG2, HG3): use image ID entry names, fix HG2 archive view.

### DIFF
--- a/ArcFormats/CatSystem/ArcHG2.cs
+++ b/ArcFormats/CatSystem/ArcHG2.cs
@@ -41,7 +41,8 @@ namespace GameRes.Formats.CatSystem
 
         public override ArcFile TryOpen (ArcView file)
         {
-            if (0x25 != file.View.ReadInt32 (8))
+            int version = file.View.ReadInt32 (8);
+            if (0x20 != version && 0x25 != version)
                 return null;
             var base_name = Path.GetFileNameWithoutExtension (file.Name);
             var dir = new List<Entry>();
@@ -50,9 +51,10 @@ namespace GameRes.Formats.CatSystem
             while (offset < file.MaxOffset)
             {
                 uint section_size = file.View.ReadUInt32 (offset+0x40);
+                int image_id = file.View.ReadInt32 (offset+0x28);
                 var entry = new Entry
                 {
-                    Name = string.Format ("{0}#{1:D4}", base_name, i),
+                    Name = string.Format ("{0}#{1:D4}", base_name, image_id),
                     Type = "image",
                     Offset = offset,
                 };
@@ -76,7 +78,8 @@ namespace GameRes.Formats.CatSystem
             var offset = entry.Offset;
             var info = new Hg2MetaData
             {
-                HeaderSize  = 0x4C,
+                Version     = arc.File.View.ReadInt32 (8),
+                HeaderSize  = arc.File.View.ReadUInt32 (offset+0x24) + 0x24,
                 Width       = arc.File.View.ReadUInt32 (offset),
                 Height      = arc.File.View.ReadUInt32 (offset+4),
                 BPP         = arc.File.View.ReadInt32 (offset+8),

--- a/ArcFormats/CatSystem/ArcHG3.cs
+++ b/ArcFormats/CatSystem/ArcHG3.cs
@@ -48,6 +48,7 @@ namespace GameRes.Formats.CatSystem
             while (offset+0x14 < file.MaxOffset && file.View.AsciiEqual (offset+8, "stdinfo"))
             {
                 uint section_size = file.View.ReadUInt32 (offset);
+                int image_id = file.View.ReadInt32 (offset+4);
                 if (0 == section_size)
                     section_size = (uint)(file.MaxOffset - offset);
                 uint stdinfo_size = file.View.ReadUInt32 (offset+0x10);
@@ -55,7 +56,7 @@ namespace GameRes.Formats.CatSystem
                 {
                     var entry = new Entry
                     {
-                        Name = string.Format ("{0}#{1:D4}", base_name, i),
+                        Name = string.Format ("{0}#{1:D4}", base_name, image_id),
                         Type = "image",
                         Offset = offset + 8,
                         Size = section_size - 8,


### PR DESCRIPTION
Change HG2/HG3 archive view entry names to use **real** ID names.<br>Fix multiple errors in `ArcHG2.cs` image view, and add version `0x20` support.

## Changes

* Fix bug in `ArcHG2.cs` where opened images would not pass `Version` to `Hg2MetaData`, causing the reader to unpack everything as version `0x10` instead.
* Add support for viewing HG2 version `0x20` as archive, and read **real** data offset when assigning the `HeaderSize` field in `Hg2MetaData`.
* HG2 and HG3 archive image names now use **real** IDs in names, instead of image index: Aside from HG2 version `0x10`, all HG\* images contain frame IDs, which are considered part of the name (at least when used in a multi-image fashion).
    * Note: A signed integer is used to match CatSystem 2 behavior. It can handle unnecessarily large and negative frame IDs, and will export frames as a signed number when using the **WGC.exe** tool (from the devkit).
    * 90% of the time, these IDs will just be the index of the frame. But the other 10%, these IDs are very specifically chosen when working with user interface layers and image variations (like a button highlight state).
    * When used for user interfaces, image IDs usually follow a pattern of reserving the lower **decimal** digits for image **variations**, and higher decimal digits for different UI elements (i.e. save/load/title/config button, background, etc.)

### Example of new frame ID names:

![new frame IDs in GARbro](https://i.imgur.com/lO0310S.png)

## About new fields referenced

<details><summary><b>HG3 fields referenced</b></summary>

### Frame Header

|Type    |Value     |Description|
|-------:|:---------|:----------|
|`uint32`|OffsetNext|Offset to the next frame|
|`uint32`|**ID**    |Identifier for the frame used in game|
|\*      |Tags      |Image tags, **must** start with `"stdinfo"` tag|

</details>
&zwj;
<details><summary><b>HG2 fields referenced</b></summary>

See **Version 0x20** fields: **ID** and **OffsetData** (referenced for the `HeaderSize` field assignment)

### Frame Metadata: Version 0x10

|Type    |Value       |Description|
|-------:|:-----------|:----------|
|`uint32`|Width       |Condensed width of the image (without transparency)|
|`uint32`|Height      |Condensed height of the image (without transparency)|
|`uint32`|BitDepth    |Number of bits per pixel, 24 or 32 (different usage with version 0x10)|
|`uint32`|Reversed1   |**Unused** *(would be the slice index, like in HG3)*|
|`uint32`|Reserved2   |**Unused** *(would be the slice length, like in HG3)* |
|`uint32`|DataSize    |Compressed length of Zero Run-length copy data|
|`uint32`|OrigDataSize|Decompressed length of Zero Run-length copy data|
|`uint32`|CtlSize     |Compressed length of Zero Run-length command bits|
|`uint32`|OrigCtlSize |Original size of Zero Run-length command bits|

### Frame Metadata: Version 0x20 (extended)

|Type    |Value         |Description|
|-------:|:-------------|:----------|
|`uint32`|**OffsetData**|Offset (relative to Version 0x20 metadata) to Image Data (Always >= `0x20`)<br>Alternatively consider as extra metadata size|
|`uint32`|**ID**        |Identifier for the frame used in game|
|`uint32`|CanvasWidth   |Total width of the image with OffsetX applied|
|`uint32`|CanvasHeight  |Total height of the image with OffsetY applied|
|`int32` |OffsetX       |Horizontal offset of the image from the left|
|`int32` |OffsetY       |Vertical offset of the image from the top|
|`bool32`|IsTransparent |True if transparency is used in the image|
|`uint32`|OffsetNext    |Offset from start of Version 0x10 to next frame<br/>Value is `0` if no more frames|

### Frame Metadata: Version 0x25 (extended)

|Type   |Value|Description|
|------:|:----|:----------|
|`int32`|BaseX|Horizontal center of the image, used for drawing in-game|
|`int32`|BaseY|Vertical center of the image, used for drawing in-game|

</details>