### PR TITLE
implemented '.zt' archives.

### DIFF
--- a/ArcFormats/ArcFormats.csproj
+++ b/ArcFormats/ArcFormats.csproj
@@ -95,6 +95,7 @@
     <Compile Include="AdvSys\ImageGWD.cs" />
     <Compile Include="Ail\ArcLNK2.cs" />
     <Compile Include="BlueGale\ImageBBM.cs" />
+    <Compile Include="CatSystem\ArcZT.cs" />
     <Compile Include="JamCreation\ArcDAT.cs" />
     <Compile Include="JamCreation\ImageDPO.cs" />
     <Compile Include="AliceSoft\ArcAAR.cs" />

--- a/ArcFormats/CatSystem/ArcZT.cs
+++ b/ArcFormats/CatSystem/ArcZT.cs
@@ -1,0 +1,120 @@
+﻿//! \file       ArcZT.cs
+//! \date       2021 May 25
+//! \brief      CatSystem2 pack file.
+//
+// Copyright (C) 2021 by morkt
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using GameRes.Compression;
+
+namespace GameRes.Formats.CatSystem
+{
+    [Export(typeof(ArchiveFormat))]
+    public class ZtOpener : ArchiveFormat
+    {
+        public override string         Tag { get { return "ZT/PACK"; } }
+        public override string Description { get { return "CatSystem2 pack file"; } }
+        public override uint     Signature { get { return 0; } }
+        public override bool  IsHierarchic { get { return true; } }
+        public override bool      CanWrite { get { return false; } }
+
+        public ZtOpener ()
+        {
+            Extensions = new string[] { "zt" };
+        }
+
+        struct ZtSubdirectory
+		{
+            public string Name;
+            public long Offset;
+		}
+
+        public override ArcFile TryOpen (ArcView file)
+        {
+            if (file.MaxOffset < 0x11C)
+                return null;
+            if (0x110 > file.View.ReadUInt32 (8) || 1 < file.View.ReadUInt32 (0xC))
+                return null; // First entry is too small, or not a file or folder
+            var dir = new List<Entry> ();
+            var subdirs = new Queue<ZtSubdirectory> ();
+            const string sep = "\\";
+            string parent_name = "";
+            long offset = 0;
+            uint offset_next;
+            do
+            {
+                offset_next     = file.View.ReadUInt32 (offset);
+                uint entry_size = file.View.ReadUInt32 (offset+8);
+                if (0 != offset_next && 0xC + entry_size > offset_next)
+                    return null;
+                uint attributes = file.View.ReadUInt32 (offset+0xC);
+                string name     = file.View.ReadString (offset+0x10, 0x104);
+                if (1 < attributes || 0 == name.Length)
+                    return null;
+
+                if (0 == attributes)
+                {
+                    var entry = FormatCatalog.Instance.Create<PackedEntry> (parent_name + name);
+                    uint packed_size = file.View.ReadUInt32 (offset+0x114);
+                    if (0x110 + packed_size != entry_size)
+                        return null;
+                    entry.Offset = offset + 0x11C;
+                    entry.Size = packed_size;
+                    entry.UnpackedSize = file.View.ReadUInt32 (offset+0x118);
+                    entry.IsPacked = true;
+                    if (!entry.CheckPlacement (file.MaxOffset))
+                        return null;
+                    dir.Add (entry);
+                }
+                else if (0 != file.View.ReadUInt32 (offset+4))
+                {
+                    subdirs.Enqueue (new ZtSubdirectory { Name = parent_name + name + sep, Offset = offset });
+                }
+
+                if (0 == offset_next && 0 != subdirs.Count)
+                {   // No more entries in current directory, go to next subdirectory
+                    var subdir = subdirs.Dequeue ();
+                    parent_name = subdir.Name;
+                    offset      = subdir.Offset;
+                    offset_next = file.View.ReadUInt32 (offset+4); // offset_child
+                    if (0xC + file.View.ReadUInt32 (offset+8) > offset_next)
+                        return null;
+                }
+                offset += offset_next;
+            }
+            while (0 != offset_next);
+
+            return new ArcFile (file, this, dir);
+        }
+
+        public override Stream OpenEntry (ArcFile arc, Entry entry)
+        {
+            var pentry = (PackedEntry)entry;
+            if (0 == pentry.UnpackedSize)
+                return Stream.Null;
+            var input = arc.File.CreateStream (entry.Offset, entry.Size);
+            return new ZLibStream (input, CompressionMode.Decompress);
+        }
+    }
+}


### PR DESCRIPTION
Add CatSystem2 archive format `ArcZT.cs` (Tag: `ZT/PACK`, Extension: `.zt`).

I wasn't sure what the best course of action for the copyright on a new file was - so the date/time/name info has been filled in, while retaining the copyright to morkt. :)

## New Format: ZT/PACK

* **Usage:** Extras/export pack files for CatSystem2 - often used to save wallpapers, wav files, or other extras to the user's computer.
* **Tag:** `ZT/PACK` (chosen over *just* `ZT`, based on the devkit tool name: `ztpack.exe`, which also describes it as a *"pack file"*).
* **Extension:** `*.zt` (found in `export.int` archive).
* **Signature:** No file signature of any kind, immediately starts with an entry structure. A lot of sanity checks have been added.
* **Hierarchic:** Yes, although this is rarely used, and CS2's implementation is rather buggy.
    * Buggy enough that Frontwing gave up and [started putting zip files **into** zt files](https://i.imgur.com/HVkJpiV.png)!
	* The specification at least, is still well defined.
* Archive layout is the standard offset-next approach seen in other CS2 formats. But there's two offset-next fields: One for subdirectory entries, and one for the next flat (current) directory entry.
    * Folders have their own entries, which are what point to child file entries.

## About fields referenced

The following entry structure is all that exists for the `.zt` format. It appears at the beginning of the file, and at every following offset.

Note that when `UnpackedSize == 0`, CS2 takes liberties to skip attempting decompression altogether. However the `Size` field is still specified, and the minimal Zlib level-9 compression RFC header and data is present.

<details><summary><b>Entry structure fields referenced</b></summary>

### Entry Structure

|Type        |Value       |Description|
|-----------:|:-----------|:----------|
|`uint32`    |OffsetNext  |Offset to the next entry in current directory (relative to this entry)|
|`uint32`    |OffsetChild |Offset to first child entry of this folder (relative to this entry)|
|`uint32`    |EntryLength |Remaining entry length (after this field)|
| | | |
|`uint32`    |Attributes  |`0` = File, `1` = Folder|
|`char[260]` |FileName    |Base file name (no parent directory names)|
|`uint32`    |Size        |Compressed size of FileData|
|`uint32`    |UnpackedSize|Decompressed size of FileData|
|`byte[Size]`|FileData    |Zlib-compressed file data|

</details>

### Additional references

* [**JP Manual:** "ztpack.exe"](http://cs2.suki.jp/manual/data/setup/ztpack.html)
* [**Writeup:** Tool: ztpack.exe](https://github.com/trigger-segfault/TriggersTools.CatSystem2/wiki/Tool:-ztpack.exe)
* [**Writeup:** Format: ZT Package](https://github.com/trigger-segfault/TriggersTools.CatSystem2/wiki/ZT-Package)