### PR TITLE
add support of PSV mpk

### DIFF
--- a/ArcFormats/NitroPlus/ArcMPK.cs
+++ b/ArcFormats/NitroPlus/ArcMPK.cs
@@ -39,22 +39,43 @@ namespace GameRes.Formats.NitroPlus
 
         public override ArcFile TryOpen (ArcView file)
         {
+            uint version_temp = file.View.ReadUInt32 (4);
             int count = file.View.ReadInt32 (8);
             if (!IsSaneCount (count))
                 return null;
-            uint index_offset = 0x48;
             var dir = new List<Entry> (count);
-            for (int i = 0; i < count; ++i)
+            uint index_offset = 0;
+            if (version_temp == 65536)
             {
-                var name = file.View.ReadString (index_offset+0x18, 0xE0);
-                var entry = Create<PackedEntry> (name);
-                entry.Offset = file.View.ReadInt64 (index_offset);
-                entry.Size = file.View.ReadUInt32 (index_offset+8);
-                entry.UnpackedSize = file.View.ReadUInt32 (index_offset+0x10);
-                if (!entry.CheckPlacement (file.MaxOffset))
-                    return null;
-                dir.Add (entry);
-                index_offset += 0x100;
+                index_offset = 0x44;
+                for (int i = 0; i < count; ++i)
+                {
+                    var name = file.View.ReadString (index_offset+0x1c, 0xE0);
+                    var entry = Create<PackedEntry> (name);
+                    entry.Offset = file.View.ReadInt32 (index_offset);
+                    entry.Size = file.View.ReadUInt32 (index_offset+4);
+                    entry.UnpackedSize = file.View.ReadUInt32 (index_offset+8);
+                    if (!entry.CheckPlacement (file.MaxOffset))
+                        return null;
+                    dir.Add (entry);
+                    index_offset += 0x100;
+                }
+            }
+            else
+            {
+                index_offset = 0x48;
+                for (int i = 0; i < count; ++i)
+                {
+				    var name = file.View.ReadString (index_offset+0x18, 0xE0);
+                    var entry = Create<PackedEntry> (name);
+                    entry.Offset = file.View.ReadInt64 (index_offset);
+                    entry.Size = file.View.ReadUInt32 (index_offset+8);
+                    entry.UnpackedSize = file.View.ReadUInt32 (index_offset+0x10);
+                    if (!entry.CheckPlacement (file.MaxOffset))
+                        return null;
+                    dir.Add (entry);
+                    index_offset += 0x100;
+                }
             }
             return new ArcFile (file, this, dir);
         }


### PR DESCRIPTION
Try to support some mpk format on PSV. It's used by 花咲くまにまに PCSG00366 and ChaosHeadLoveChuChu PCSG00435.
I can't compile it on local, so I'm not sure if this edit is effective. The following is a python version of the processing method.
https://github.com/Manicsteiner/ChaosChildPCTools/blob/master/mpk.py