### PR TITLE
(GUI): fix zh-Hans translation of `LabelEncoding`

### DIFF
--- a/GUI/Strings/guiStrings.zh-Hans.resx
+++ b/GUI/Strings/guiStrings.zh-Hans.resx
@@ -394,7 +394,7 @@
     <value>转换错误。</value>
   </data>
   <data name="LabelEncoding" xml:space="preserve">
-    <value>正在编码</value>
+    <value>编码</value>
   </data>
   <data name="TextConvertAudio" xml:space="preserve">
     <value>将音频转换为常规格式</value>


### PR DESCRIPTION
zh-Hans translation of `LabelEncoding` with text "Encoding" in English is wrong.
The current translation "正在编码" means "Currently encoding", in which encoding is not a noun but verb.
The correct translation is "编码".