### PR TITLE
Add an automation-friendly command-line version (continues #394)

### DIFF
--- a/ArcFormats/ArcFormats.csproj
+++ b/ArcFormats/ArcFormats.csproj
@@ -1276,13 +1276,8 @@ exit 0</PreBuildEvent>
     <PostBuildEvent>if not exist "$(TargetDir)\GameData" mkdir "$(TargetDir)\GameData"
 xcopy "$(ProjectDir)\Resources\Formats.dat" "$(TargetDir)\GameData\" /D /Y &gt;NUL</PostBuildEvent>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
+  <!-- legacy MSBuild-integrated NuGet restore (.nuget\NuGet.targets) removed; packages are restored via `nuget restore` -->
+
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Console/ConsoleBrowser.cs
+++ b/Console/ConsoleBrowser.cs
@@ -256,8 +256,14 @@ namespace GARbro {
 		}
 
 		Stream CreateNewFile(string filename) {
-			var path = Path.Combine(outputDirectory, filename);
-			path = Path.GetFullPath(path);
+			var outputRoot = Path.GetFullPath(outputDirectory);
+			var path = Path.GetFullPath(Path.Combine(outputRoot, filename));
+			var rootWithSep = outputRoot.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+				? outputRoot : outputRoot + Path.DirectorySeparatorChar;
+			if (!path.StartsWith(rootWithSep, StringComparison.OrdinalIgnoreCase)) {
+				throw new UnauthorizedAccessException(string.Format(
+					"Refusing to extract entry outside output directory: '{0}'", filename));
+			}
 			Directory.CreateDirectory(Path.GetDirectoryName(path));
 
 			if (File.Exists(path)) {

--- a/Console/ConsoleBrowser.cs
+++ b/Console/ConsoleBrowser.cs
@@ -38,6 +38,7 @@ namespace GARbro {
 		private bool skipAudio;
 		private bool convertAudio;
 		private bool adjustImageOffset;
+		private static bool quiet;
 
 		private ExistingFileAction existingFileAction = ExistingFileAction.Ask;
 		
@@ -102,8 +103,8 @@ namespace GARbro {
 				}
 			}
 
-			Console.WriteLine();
-			Console.WriteLine(iSkipped > 0? iSkipped + " files were skipped": "All OK");
+			if (iSkipped > 0) Environment.ExitCode = 1;
+			if (!quiet) Console.Error.WriteLine(iSkipped > 0? iSkipped + " files were skipped": "All OK");
 		}
 
 		void Archive_ExtractConvertedImage(ArcFile arc, Entry entry) {
@@ -370,8 +371,24 @@ namespace GARbro {
 					case "-ocu":
 						autoImageFormat = true;
 						break;
+					case "-y":
+					case "--overwrite":
+						existingFileAction = ExistingFileAction.Overwrite;
+						break;
+					case "-s":
+					case "--skip":
+						existingFileAction = ExistingFileAction.Skip;
+						break;
+					case "-r":
+					case "--rename":
+						existingFileAction = ExistingFileAction.Rename;
+						break;
+					case "-q":
+					case "--quiet":
+						quiet = true;
+						break;
 					default:
-						Console.WriteLine("Warning: Unknown command line parameter: " + args[i]);
+						PrintError("Unknown command line parameter: " + args[i]);
 						return;
 				}
 			}
@@ -418,8 +435,6 @@ namespace GARbro {
 
 			var fileArray = fileList.OrderBy(e => e.Offset).ToArray();
 
-			Console.WriteLine(fileArray[0].Offset);
-
 			switch (command) {
 				case ConsoleCommand.Info:
 					Console.WriteLine(archiveFileSystem.Source.Tag);
@@ -441,7 +456,7 @@ namespace GARbro {
 		/// <param name="command"></param>
 		void ProcessNonArchiveFile(string file, ConsoleCommand command) {
 			var fileName = Path.GetFileName(file);
-			if (fileFilter != null && fileFilter.IsMatch(fileName)) PrintError("No files match the given filter");
+			if (fileFilter != null && !fileFilter.IsMatch(fileName)) { PrintError("No files match the given filter"); return; }
 
 			switch (command) {
 				case ConsoleCommand.Info:
@@ -514,23 +529,32 @@ namespace GARbro {
 			Console.WriteLine("  -ns       	   Ignore scripts");
 			Console.WriteLine("  -aio       	   Adjust image offset");
 			Console.WriteLine("  -ocu       	   Set -if switch to only convert unknown image formats");
+			Console.WriteLine("  -y, --overwrite  Overwrite existing files without prompting (default when non-interactive)");
+			Console.WriteLine("  -s, --skip       Skip existing files");
+			Console.WriteLine("  -r, --rename     Write to a new name instead of overwriting");
+			Console.WriteLine("  -q, --quiet      Suppress banner/progress (errors still go to stderr)");
 			Console.WriteLine();
 			//Console.WriteLine(FormatCatalog.Instance.ArcFormats.Count() + " supported formats");
 		}
 
 		static void PrintProgress(int current, int total, string fileName) {
-			Console.WriteLine(string.Format("[{0}/{1}] {2}", current, total, fileName));
+			if (quiet) return;
+			Console.Error.WriteLine(string.Format("[{0}/{1}] {2}", current, total, fileName));
 		}
 
 		static void PrintWarning(string msg) {
-			Console.WriteLine("Warning: " + msg);
+			if (quiet) return;
+			Console.Error.WriteLine("Warning: " + msg);
 		}
 
 		static void PrintError(string msg) {
-			Console.WriteLine("Error: " + msg);
+			Console.Error.WriteLine("Error: " + msg);
+			Environment.ExitCode = 1;
 		}
 
 		string OverwritePrompt(string filename) {
+			// Non-interactive (redirected stdin / no console): never block on a prompt.
+			if (existingFileAction == ExistingFileAction.Ask && Console.IsInputRedirected) return filename;
 			switch (existingFileAction) {
 				
 				case ExistingFileAction.Skip:
@@ -597,8 +621,8 @@ namespace GARbro {
 
 		static void Main(string[] args) {
 			Console.OutputEncoding = Encoding.UTF8;
-			Console.WriteLine(string.Format("GARbro - Game Resource browser, version {0}\n2014-2020 by mørkt, published under a MIT license", Assembly.GetAssembly(typeof(FormatCatalog)).GetName().Version));
-			Console.WriteLine("-----------------------------------------------------------------------------\n");
+			Console.Error.WriteLine(string.Format("GARbro - Game Resource browser, version {0}\n2014-2020 by mørkt, published under a MIT license", Assembly.GetAssembly(typeof(FormatCatalog)).GetName().Version));
+			Console.Error.WriteLine("-----------------------------------------------------------------------------\n");
 
 			FormatCatalog.Instance.ParametersRequest += OnParametersRequest;
 			//var listener = new TextWriterTraceListener(Console.Error);

--- a/Console/ConsoleBrowser.cs
+++ b/Console/ConsoleBrowser.cs
@@ -1,198 +1,444 @@
-﻿//! \file       Program.cs
-//! \date       Mon Jun 30 20:12:13 2014
-//! \brief      game resources browser.
-//
-
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
-using System.IO.MemoryMappedFiles;
 using System.Text;
 using System.Linq;
-using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Media.Imaging;
 using GameRes;
+// ReSharper disable LocalizableElement
 
-namespace GARbro
-{
-    class ConsoleBrowser
-    {
-        private string      m_arc_name;
-        private ImageFormat m_image_format;
-        private bool        m_extract_all;
+namespace GARbro {
+	public enum ExistingFileAction {
+		Ask,
+		Skip,
+		Overwrite,
+		Rename
+	}
 
-        void ListFormats ()
-        {
-            Console.WriteLine ("Recognized resource formats:");
-            foreach (var impl in FormatCatalog.Instance.ArcFormats)
-            {
-                Console.WriteLine ("{0,-4} {1}", impl.Tag, impl.Description);
-            }
-        }
+	class ConsoleBrowser {
+		private string outputDirectory;
 
-        void ExtractAll (ArcFile arc)
-        {
-            arc.ExtractFiles ((i, entry, msg) => {
-                if (null != entry)
-                {
-                    Console.WriteLine ("Extracting {0} ...", entry.Name);
-                }
-                else if (null != msg)
-                {
-                    Console.WriteLine (msg);
-                }
-                return ArchiveOperation.Continue;
-            });
-        }
+		private Regex fileFilter;
+		private ImageFormat imageFormat;
+		private bool autoImageFormat = false;
+		private bool ignoreErrors = true;
+		private bool skipImages;
+		private bool skipScript;
+		private bool skipAudio;
+		private bool convertAudio;
+		private bool adjustImageOffset;
 
-        void ExtractFile (ArcFile arc, string name)
-        {
-            Entry entry = arc.Dir.FirstOrDefault (e => e.Name.Equals (name, StringComparison.OrdinalIgnoreCase));
-            if (null == entry)
-            {
-                Console.Error.WriteLine ("'{0}' not found within {1}", name, m_arc_name);
-                return;
-            }
-            Console.WriteLine ("Extracting {0} ...", entry.Name);
-            arc.Extract (entry);
-        }
+		private ExistingFileAction existingFileAction = ExistingFileAction.Ask;
+		
+		public static readonly HashSet<string> CommonAudioFormats = new HashSet<string> {"wav", "mp3", "ogg"};
+		public static readonly HashSet<string> CommonImageFormats = new HashSet<string> {"jpeg", "png", "bmp", "tga"};
 
-        void TestArc (string[] args)
-        {
-/*
-            if (args.Length > 1)
-            {
-                uint pass = GameRes.Formats.IntOpener.EncodePassPhrase (args[1]);
-                Console.WriteLine ("{0:X8}", pass);
-            }
-*/
-        }
+		private void ListFormats() {
+			Console.WriteLine("Recognized resource formats:\n");
+			foreach (var format in FormatCatalog.Instance.ArcFormats.OrderBy(format => format.Tag)) {
+				Console.WriteLine("{0,-20} {1}", format.Tag, format.Description);
+			}
+		}
 
-        void Run (string[] args)
-        {
-            int argn = 0;
-            while (argn < args.Length)
-            {
-                if (args[argn].Equals ("-l"))
-                {
-                    ListFormats();
-                    return;
-                }
-                else if (args[argn].Equals ("-t"))
-                {
-                    TestArc (args);
-                    return;
-                }
-                else if (args[argn].Equals ("-c"))
-                {
-                    if (argn+1 >= args.Length)
-                    {
-                        Usage();
-                        return;
-                    }
-                    var tag = args[argn+1];
-                    m_image_format = ImageFormat.FindByTag (tag);
-                    if (null == m_image_format)
-                    {
-                        Console.Error.WriteLine ("{0}: unknown format specified", tag);
-                        return;
-                    }
-                    argn += 2;
-                }
-                else if (args[argn].Equals ("-x"))
-                {
-                    m_extract_all = true;
-                    ++argn;
-                    if (args.Length <= argn)
-                    {
-                        Usage();
-                        return;
-                    }
-                }
-                else
-                {
-                    break;
-                }
-            }
-            if (argn >= args.Length)
-            {
-                Usage();
-                return;
-            }
-            DeserializeGameData();
-            foreach (var file in VFS.GetFiles (args[argn]))
-            {
-                m_arc_name = file.Name;
-                try
-                {
-                    VFS.ChDir (m_arc_name);
-                }
-                catch (Exception)
-                {
-                    Console.Error.WriteLine ("{0}: unknown format", m_arc_name);
-                    continue;
-                }
-                var arc = ((ArchiveFileSystem)VFS.Top).Source;
-                if (args.Length > argn+1)
-                {
-                    for (int i = argn+1; i < args.Length; ++i)
-                        ExtractFile (arc, args[i]);
-                }
-                else if (m_extract_all)
-                {
-                    ExtractAll (arc);
-                }
-                else
-                {
-                    foreach (var entry in arc.Dir.OrderBy (e => e.Offset))
-                    {
-                        Console.WriteLine ("{0,9} [{2:X8}] {1}", entry.Size, entry.Name, entry.Offset);
-                    }
-                }
-            }
-        }
+		private void ListFiles(Entry[] fileList) {
+			Console.WriteLine("     Offset      Size  Name");
+			Console.WriteLine(" ----------  --------  ------------------------------------------------------");
+			foreach (var entry in fileList) {
+				Console.WriteLine(" [{1:X8}] {0,9}  {2}", entry.Offset, entry.Size, entry.Name);
+			}
 
-        void DeserializeGameData ()
-        {
-            string scheme_file = Path.Combine (FormatCatalog.Instance.DataDirectory, "Formats.dat");
-            try
-            {
-                using (var file = File.OpenRead (scheme_file))
-                    FormatCatalog.Instance.DeserializeScheme (file);
-            }
-            catch (Exception X)
-            {
-                Console.Error.WriteLine ("Scheme deserialization failed: {0}", X.Message);
-            }
-        }
+			Console.WriteLine(" ----------  --------  ------------------------------------------------------");
+			Console.WriteLine($"                       {fileList.Length} files");
+		}
 
-        static void Usage ()
-        {
-            Console.WriteLine ("Usage: gameres [OPTIONS] ARC [ENTRIES]");
-            Console.WriteLine ("    -l          list recognized archive formats");
-            Console.WriteLine ("    -x          extract all files");
-            Console.WriteLine ("    -c FORMAT   convert images to specified format");
-            Console.WriteLine ("Without options displays contents of specified archive.");
-        }
+		private void ExtractFiles(Entry[] fileList, ArcFile arc) {
+			Directory.CreateDirectory(outputDirectory);
 
-        static void Main (string[] args)
-        {
-            Console.OutputEncoding = Encoding.UTF8;
-            if (0 == args.Length)
-            {
-                Usage();
-                return;
-            }
-            var listener = new TextWriterTraceListener (Console.Error);
-            Trace.Listeners.Add(listener);
-            try
-            {
-                var browser = new ConsoleBrowser();
-                browser.Run (args);
-            }
-            catch (Exception X)
-            {
-                Console.Error.WriteLine (X.Message);
-            }
-        }
-    }
+			var iSkipped = 0;
+			for (var i = 0; i < fileList.Length; i++) {
+				var entry = fileList[i];
+				Console.WriteLine(string.Format("[{0}/{1}] {2}", i + 1, fileList.Length, entry.Name));
+				
+				try {
+					if (imageFormat != null && entry.Type == "image") {
+						ExtractImage(arc, entry, imageFormat);
+					}
+					else if (convertAudio && entry.Type == "audio") {
+						ExtractAudio(arc, entry);
+					}
+					else {
+						using (var input = arc.OpenEntry(entry))
+						using (var output = CreateNewFile(entry.Name))
+							input.CopyTo(output);
+					}
+				}
+				catch (TargetException) {
+					iSkipped++;
+				}
+#if !DEBUG
+				catch (Exception e) {
+					PrintError(string.Format($"Failed to extract {entry.Name}: {e.Message}"));
+					if (!ignoreErrors) return;
+
+					iSkipped++;
+				}
+#endif
+			}
+
+			Console.WriteLine();
+			Console.WriteLine(iSkipped > 0? iSkipped + " files were skipped": "All OK");
+		}
+
+		void ExtractImage(ArcFile arc, Entry entry, ImageFormat targetFormat) {
+			using (var decoder = arc.OpenImage(entry)) {
+				var src_format = decoder.SourceFormat; // could be null
+
+				if (autoImageFormat && src_format != null) targetFormat = CommonImageFormats.Contains(src_format.Tag.ToLower())? src_format: ImageFormat.Png;
+
+				var target_ext = targetFormat.Extensions.FirstOrDefault() ?? "";
+				var outputName = Path.ChangeExtension(entry.Name, target_ext);
+				if (src_format == targetFormat) {
+					// source format is the same as a target, copy file as is
+					using (var output = CreateNewFile(outputName)) decoder.Source.CopyTo(output);
+					return;
+				}
+
+				var image = decoder.Image;
+				if (adjustImageOffset) image = AdjustImageOffset(image);
+
+				using (var outfile = CreateNewFile(outputName)) {
+					targetFormat.Write(outfile, image);
+				}
+			}
+		}
+
+		static ImageData AdjustImageOffset(ImageData image) {
+			if (0 == image.OffsetX && 0 == image.OffsetY) return image;
+			var width = (int) image.Width + image.OffsetX;
+			var height = (int) image.Height + image.OffsetY;
+			if (width <= 0 || height <= 0) return image;
+
+			var x = Math.Max(image.OffsetX, 0);
+			var y = Math.Max(image.OffsetY, 0);
+			var src_x = image.OffsetX < 0? Math.Abs(image.OffsetX): 0;
+			var src_y = image.OffsetY < 0? Math.Abs(image.OffsetY): 0;
+			var src_stride = (int) image.Width * (image.BPP + 7) / 8;
+			var dst_stride = width * (image.BPP + 7) / 8;
+			var pixels = new byte[height * dst_stride];
+			var offset = y * dst_stride + x * image.BPP / 8;
+			var rect = new Int32Rect(src_x, src_y, (int) image.Width - src_x, 1);
+			for (var row = src_y; row < image.Height; ++row) {
+				rect.Y = row;
+				image.Bitmap.CopyPixels(rect, pixels, src_stride, offset);
+				offset += dst_stride;
+			}
+
+			var bitmap = BitmapSource.Create(width, height, image.Bitmap.DpiX, image.Bitmap.DpiY,
+				image.Bitmap.Format, image.Bitmap.Palette, pixels, dst_stride);
+			return new ImageData(bitmap);
+		}
+
+		void ExtractAudio(ArcFile arc, Entry entry) {
+			using (var file = arc.OpenBinaryEntry(entry))
+			using (var sound = AudioFormat.Read(file)) {
+				if (sound == null) throw new InvalidFormatException("Unable to interpret audio format");
+				ConvertAudio(entry.Name, sound);
+			}
+		}
+
+		public void ConvertAudio(string filename, SoundInput input) {
+			var source_format = input.SourceFormat;
+			if (CommonAudioFormats.Contains(source_format)) {
+				var output_name = Path.ChangeExtension(filename, source_format);
+				using (var output = CreateNewFile(output_name)) {
+					input.Source.Position = 0;
+					input.Source.CopyTo(output);
+				}
+			}
+			else {
+				var output_name = Path.ChangeExtension(filename, "wav");
+				using (var output = CreateNewFile(output_name)) AudioFormat.Wav.Write(input, output);
+			}
+		}
+
+		protected Stream CreateNewFile(string filename) {
+			var path = Path.Combine(outputDirectory, filename);
+			path = Path.GetFullPath(path);
+			Directory.CreateDirectory(Path.GetDirectoryName(path));
+
+			if (File.Exists(path)) {
+				path = OverwritePrompt(path);
+				if (path == null) throw new TargetException();
+			}
+
+			return File.Open(path, FileMode.Create);
+		}
+
+		void Run(string[] args) {
+			var command = args.Length < 1? "h": args[0];
+
+			switch (command) {
+				case "h":
+				case "-h":
+				case "--help":
+				case "/?":
+				case "-?":
+					Usage();
+					return;
+				case "f":
+					ListFormats();
+					return;
+			}
+
+			if (command.Length != 1) {
+				PrintError(File.Exists(command)? "No command specified. Use -h command line parameter to show help.": "Invalid command: " + command);
+				return;
+			}
+			if (args.Length < 2) {
+				PrintError("No archive file specified");
+				return;
+			}
+
+			var inputFile = args[args.Length - 1];
+			if (!File.Exists(inputFile)) {
+				PrintError("Input file " + inputFile + " does not exist");
+				return;
+			}
+
+			var argLength = args.Length - 1;
+			outputDirectory = Directory.GetCurrentDirectory();
+			for (var i = 1; i < argLength; i++) {
+				switch (args[i]) {
+					case "-o":
+						i++;
+						if (i >= argLength) {
+							PrintError("No output directory specified");
+							return;
+						}
+						outputDirectory = args[i];
+						if (File.Exists(outputDirectory)) {
+							PrintError("Invalid output directory");
+							return;
+						}
+
+						//Directory.SetCurrentDirectory(outputDirectory);
+						break;
+					case "-f":
+						i++;
+						if (i >= argLength) {
+							PrintError("No filter specified");
+							return;
+						}
+
+						try {
+							fileFilter = new Regex(args[i]);
+						}
+						catch (ArgumentException e) {
+							PrintError("Invalid filter: " + e.Message);
+							return;
+						}
+
+						break;
+					case "-if":
+						i++;
+						var formatTag = args[i].ToUpper();
+						if (formatTag == "JPG") formatTag = "JPEG";
+
+						imageFormat = ImageFormat.FindByTag(formatTag);
+						if (imageFormat == null) {
+							PrintError("Unknown image format specified: " + args[i]);
+							return;
+						}
+						break;
+					case "-ca":
+						convertAudio = true;
+						break;
+					case "-na":
+						skipAudio = true;
+						break;
+					case "-ni":
+						skipImages = true;
+						break;
+					case "-ns":
+						skipScript = true;
+						break;
+					case "-aio":
+						adjustImageOffset = true;
+						break;
+					case "-ocu":
+						autoImageFormat = true;
+						break;
+					default:
+						Console.WriteLine("Warning: Unknown command line parameter: " + args[i]);
+						return;
+				}
+			}
+
+			if (autoImageFormat && imageFormat == null) {
+				PrintError("The parameter -ocu requires the image format (-if parameter) to be set");
+				return;
+			}
+
+			DeserializeGameData();
+
+			try {
+				VFS.ChDir(inputFile);
+			}
+			catch (Exception) {
+				PrintError("Input file has an unknown format");
+				return;
+			}
+
+			var m_fs = (ArchiveFileSystem) VFS.Top;
+			var fileList = m_fs.GetFilesRecursive().Where(e => e.Offset >= 0);
+
+			if (skipImages || skipScript || skipAudio|| fileFilter != null) {
+				fileList = fileList.Where(f => !(skipImages && f.Type == "image") &&
+											   !(skipScript && f.Type == "script") &&
+											   !(skipAudio && f.Type == "audio") &&
+											   (fileFilter == null || fileFilter.IsMatch(f.Name)));
+			}
+
+			if (!fileList.Any()) {
+				var hasFilter = skipAudio || skipImages || skipScript || fileFilter != null;
+				PrintError(hasFilter? "No files match the given filter": "Archive is empty");
+				return;
+			}
+
+			var fileArray = fileList.OrderBy(e => e.Offset).ToArray();
+
+			Console.WriteLine(fileArray[0].Offset);
+
+			switch (command) {
+				case "i":
+					Console.WriteLine(m_fs.Source.Tag);
+					break;
+				case "l":
+					ListFiles(fileArray);
+					break;
+				case "x":
+					ExtractFiles(fileArray, m_fs.Source);
+					break;
+			}
+		}
+
+		void DeserializeGameData() {
+			var scheme_file = Path.Combine(FormatCatalog.Instance.DataDirectory, "Formats.dat");
+			try {
+				using (var file = File.OpenRead(scheme_file)) FormatCatalog.Instance.DeserializeScheme(file);
+			}
+			catch (Exception) {
+				//Console.Error.WriteLine("Scheme deserialization failed: {0}", e.Message);
+			}
+		}
+		
+		static void Usage() {
+			Console.WriteLine(string.Format("Usage: {0} <command> [<switches>...] <archive_name>", Process.GetCurrentProcess().ProcessName));
+			Console.WriteLine("\nCommands:");
+			Console.WriteLine("  i   Identify archive format");
+			Console.WriteLine("  f   List supported formats");
+			Console.WriteLine("  l   List contents of archive");
+			Console.WriteLine("  x   Extract files from archive");
+			Console.WriteLine("\nSwitches:");
+			Console.WriteLine("  -o <Directory>   Set output directory for extraction");
+			Console.WriteLine("  -f <Filter>	   Only process files matching the regular expression <Filter>");
+			Console.WriteLine("  -if <Format>	   Set image output format  (e.g. 'png', 'jpg', 'bmp')");
+			Console.WriteLine("  -ca       	   Convert audio files to wav format");
+			Console.WriteLine("  -na       	   Ignore audio files");
+			Console.WriteLine("  -ni       	   Ignore image files");
+			Console.WriteLine("  -ns       	   Ignore scripts");
+			Console.WriteLine("  -aio       	   Adjust image offset");
+			Console.WriteLine("  -ocu       	   Set -if switch to only convert unknown image formats");
+			Console.WriteLine();
+			//Console.WriteLine(FormatCatalog.Instance.ArcFormats.Count() + " supported formats");
+		}
+
+		static void PrintError(string msg) {
+			Console.WriteLine("Error: " + msg);
+		}
+
+		string OverwritePrompt(string filename) {
+			switch (existingFileAction) {
+				
+				case ExistingFileAction.Skip:
+					return null;
+				case ExistingFileAction.Overwrite:
+					return filename;
+				case ExistingFileAction.Rename:
+					return GetPathToRename(filename);
+			}
+
+			Console.WriteLine(string.Format($"The file {filename} already exists. Overwrite? [Y]es | [N]o | [A]lways | n[E]ver | [R]ename | A[l]ways rename"));
+
+			while (true) {
+				switch (Console.Read()) {
+					case 'y':
+					case 'Y':
+						return filename;
+					case 'n':
+					case 'N':
+						return null;
+					case 'a':
+					case 'A':
+						existingFileAction = ExistingFileAction.Overwrite;
+						return filename;
+					case 'e':
+					case 'E':
+						existingFileAction = ExistingFileAction.Skip;
+						return null;
+					case 'r':
+					case 'R':
+						return GetPathToRename(filename);
+					case 'l':
+					case 'L':
+						existingFileAction = ExistingFileAction.Rename;
+						return GetPathToRename(filename);
+				}
+			}
+		}
+
+		string GetPathToRename(string path) {
+			var directory = Path.GetDirectoryName(path);
+			var fileName = Path.GetFileNameWithoutExtension(path);
+			var fileExtension = Path.GetExtension(path);
+
+			var i = 2;
+			do {
+				path = Path.Combine(directory, string.Format($"{fileName} ({i}){fileExtension}"));
+				i++;
+			} while (File.Exists(path));
+
+			return path;
+		}
+
+		private static void OnParametersRequest(object sender, ParametersRequestEventArgs eventArgs) {
+			// Some archives are encrypted or require parameters to be set.
+			// Let's just use the default values for now.
+			var format = (IResource) sender;
+			//Console.WriteLine(eventArgs.Notice);
+			eventArgs.InputResult = true;
+			eventArgs.Options = format.GetDefaultOptions();
+		}
+
+		static void Main(string[] args) {
+			Console.OutputEncoding = Encoding.UTF8;
+			Console.WriteLine(string.Format("GARbro - Game Resource browser, version {0}\n2014-2019 by mørkt, published under a MIT license", Assembly.GetAssembly(typeof(FormatCatalog)).GetName().Version));
+			Console.WriteLine("-----------------------------------------------------------------------------\n");
+
+			FormatCatalog.Instance.ParametersRequest += OnParametersRequest;
+			//var listener = new TextWriterTraceListener(Console.Error);
+			//Trace.Listeners.Add(listener);
+
+			var browser = new ConsoleBrowser();
+			browser.Run(args);
+
+#if DEBUG
+			Console.Read();
+#endif
+		}
+	}
 }

--- a/Console/ConsoleBrowser.cs
+++ b/Console/ConsoleBrowser.cs
@@ -201,7 +201,7 @@ namespace GARbro {
 			using (var soundInput = AudioFormat.Read(binaryStream)) {
 				if (soundInput == null) return false;
 
-				Console.WriteLine($"Converting {soundInput.SourceFormat} audio");
+				Console.Error.WriteLine($"Converting {soundInput.SourceFormat} audio");
 				ConvertAudio(fileName, soundInput);
 			}
 
@@ -350,6 +350,10 @@ namespace GARbro {
 						break;
 					case "-if":
 						i++;
+						if (i >= argLength) {
+							PrintError("No image format specified");
+							return;
+						}
 						var formatTag = args[i].ToUpper();
 						if (formatTag == "JPG") formatTag = "JPEG";
 
@@ -478,7 +482,7 @@ namespace GARbro {
 					ListFiles(new Entry[] { entry });
 					break;
 				case ConsoleCommand.Extract:
-					if (ConvertFile(file)) Console.WriteLine("All OK");
+					if (ConvertFile(file)) Console.Error.WriteLine("All OK");
 					break;
 			}
 		}

--- a/Console/GARbro.Console.csproj
+++ b/Console/GARbro.Console.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>GARbro.Console</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -23,10 +25,8 @@
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -58,7 +58,11 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>GARbro.ConsoleBrowser</StartupObject>
+  </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -66,6 +70,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConsoleBrowser.cs" />

--- a/Console/README.md
+++ b/Console/README.md
@@ -1,7 +1,31 @@
-GameRes.Console
+GARbro.Console
 ===============
 
-Console utility that extracts files from game archives.  Used as a testing
-playground for GameRes library.
+Standalone command line version of GARbro, which can list and extract files from supported archives.
 
-No longer developed.
+### Usage
+
+`GARbro.Console.exe <command> [<switches>...] <archive_name>`
+
+###### Commands:
+
+| Command | Description                                                  |
+| ------- | ------------------------------------------------------------ |
+| i       | Identify archive format                                      |
+| f       | Display supported formats. This prints a list of all formats GARbro can recognize. |
+| l       | List contents of archive                                     |
+| x       | Extract files from archive                                   |
+
+###### Switches:
+
+| Switch         | Description                                                  |
+| -------------- | ------------------------------------------------------------ |
+| -o <Directory> | Set output directory for extraction                          |
+| -f <Filter>    | Only process files matching the regular expression <Filter>  |
+| -if <Format>   | Set image output format  (e.g. 'png', 'jpg', 'bmp'). This converts all image files to the specified format. Caution: conversion might reduce the image quality and transparency can be lost (depending on the output format). Use the `-ocu` switch to skip common image formats. |
+| -ca            | Convert audio files to wav format; without this switch the original format is retained |
+| -na            | Skip audio files                                             |
+| -ni            | Skip image files                                             |
+| -ns            | Skip scripts                                                 |
+| -aio           | Adjust image offset                                          |
+| -ocu           | Set -if switch to only convert unknown image formats.<br />The default behavior of `-if` is to convert all images to the specified format. This might not desirable because it reduces the image quality or transparency information can be lost. With the `-ocu` switch only uncommon formats are converted - for example jpg and png files are kept as is, while proprietary formats are converted. |

--- a/GUI/GARbro.GUI.csproj
+++ b/GUI/GARbro.GUI.csproj
@@ -344,13 +344,8 @@ exit 0</PreBuildEvent>
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
+  <!-- legacy MSBuild-integrated NuGet restore (.nuget\NuGet.targets) removed; packages are restored via `nuget restore` -->
+
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/GameRes/GameRes.csproj
+++ b/GameRes/GameRes.csproj
@@ -127,13 +127,8 @@
     <PreBuildEvent>perl "$(SolutionDir)inc-revision.pl" "$(ProjectPath)" $(ConfigurationName)
 exit 0</PreBuildEvent>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
+  <!-- legacy MSBuild-integrated NuGet restore (.nuget\NuGet.targets) removed; packages are restored via `nuget restore` -->
+
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
This continues @Bioruebe's #394 (a new command-line version of GARbro), rebased onto current `master`, with changes that make the CLI usable as a child process driven by other tools.

### What's here
- The **CLI** (`i` identify / `f` formats / `l` list / `x` extract) from #394 by @Bioruebe — both commits cherry-picked with their original authorship preserved.
- **Subprocess hardening** on top:
  - Non-interactive file handling: add `-y`/`-s`/`-r`, and fall back to overwrite automatically when stdin is redirected. The previous code blocked on `Console.ReadKey()` with no way to answer from a script.
  - Real exit codes: `PrintError` now sets `Environment.ExitCode`, and extraction returns non-zero when files are skipped (it always exited `0` before).
  - Output hygiene: banner / progress / warnings / errors go to **stderr** so the `i`/`l` data on **stdout** is clean to parse; add `-q`.
  - Remove a leftover debug print of the first entry offset; fix an inverted filter check in the non-archive path.
- **Build fix**: drop the legacy `<Import ...\.nuget\NuGet.targets>` + `EnsureNuGetPackageBuildImports` gate from GameRes / ArcFormats / GUI so the solution builds on modern MSBuild via `nuget restore` (the `.nuget` folder is not in the tree).

### Verified
Built Console + GameRes + ArcFormats (Release) with VS Build Tools 2022. On a SoftPal `PAC/AMUSE` archive, the extracted `SCRIPT.SRC` / `TEXT.DAT` / `POINT.DAT` are byte-for-byte identical (SHA-256) to reference output.

### Note
This is also maintained, with prebuilt Windows releases, at https://github.com/Alex123666tw/garbro-cli (MIT). Happy to split commits, narrow the scope, or drop the build/doc parts if you'd prefer a more minimal PR.
